### PR TITLE
side-Groups 修正

### DIFF
--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -9,5 +9,5 @@
           = icon('fas', 'cog', class: 'edit-icon')
   .Side-bar__group-list
     .Groups
-      %p.Group__name test
-      %p.Group__message test
+      %p.Groups__name test
+      %p.Groups__message test


### PR DESCRIPTION
Whay
GroupをGroupsに修正した

Why
マージンが適用されていなかったため